### PR TITLE
Mark Data.HashSet as Trustworthy

### DIFF
--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -2,6 +2,9 @@
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE TypeFamilies #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 
 ------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
For use in Safe Haskell, matching Data.HashMap.{Lazy,Strict}.