### PR TITLE
Add role annotations

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternGuards #-}
 #if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
 #endif
 {-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
@@ -144,6 +145,10 @@ data HashMap k v
     | Full !(A.Array (HashMap k v))
     | Collision !Hash !(A.Array (Leaf k v))
       deriving (Typeable)
+
+#if __GLASGOW_HASKELL__ >= 708
+type role HashMap nominal representational
+#endif
 
 instance (NFData k, NFData v) => NFData (HashMap k v) where
     rnf Empty                 = ()
@@ -607,8 +612,8 @@ adjust f k0 m0 = go h0 k0 0 m0
         | otherwise = t
 {-# INLINABLE adjust #-}
 
--- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@, 
--- (if it is in the map). If (f k x) is @'Nothing', the element is deleted. 
+-- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@,
+-- (if it is in the map). If (f k x) is @'Nothing', the element is deleted.
 -- If it is (@'Just' y), the key k is bound to the new value y.
 update :: (Eq k, Hashable k) => (a -> Maybe a) -> k -> HashMap k a -> HashMap k a
 update f = alter (>>= f)

--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP, DeriveDataTypeable #-}
 #if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
 #endif
 #if __GLASGOW_HASKELL__ >= 702
@@ -94,6 +95,10 @@ import qualified GHC.Exts as Exts
 newtype HashSet a = HashSet {
       asMap :: HashMap a ()
     } deriving (Typeable)
+
+#if __GLASGOW_HASKELL__ >= 708
+type role HashSet nominal
+#endif
 
 instance (NFData a) => NFData (HashSet a) where
     rnf = rnf . asMap


### PR DESCRIPTION
For GHC 7.8+, this adds role annotations like the ones that are currently present in `containers`. Fixes #73.