### PR TITLE
Export HashSet constructor and accessor

### DIFF
--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -30,7 +30,7 @@
 
 module Data.HashSet
     (
-      HashSet
+      HashSet(..)
 
     -- * Construction
     , empty


### PR DESCRIPTION
It would be useful to use HashSets as key sets (for difference / intersection oprations). Unfortunately there doesn't seem to be a cheap way to do this now, but it seems that exposing the newtype constructor would achieve this.