### PR TITLE
add Generics instance for Data.HashMap

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -4,6 +4,8 @@
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE EmptyDataDecls #-}
 #endif
 {-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
 
@@ -123,6 +125,7 @@ import GHC.Exts (isTrue#)
 #endif
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts
+import GHC.Generics hiding (Prefix, prec)
 #endif
 
 
@@ -1255,4 +1258,30 @@ instance (Eq k, Hashable k) => Exts.IsList (HashMap k v) where
     type Item (HashMap k v) = (k, v)
     fromList = fromList
     toList   = toList
+
+-- Generic instance
+type LP k = [] :.: Rec1 ((,) k)   -- list of pairs; LP k v ~ [(k, v)] so LP k ~ [(k, *)]
+type Rep1HashMap k = D1 D1HashMap (C1 C1HashMap (S1 NoSelector (LP k)))
+
+instance (Eq k, Hashable k) => Generic1 (HashMap k) where
+    type Rep1 (HashMap k) = Rep1HashMap k
+    from1 h = M1 (M1 (M1 (Comp1 (Rec1 <$> toList h))))
+    to1 (M1 (M1 (M1 l))) = fromList (unRec1 <$> unComp1 l)
+
+data D1HashMap
+data C1HashMap
+
+instance Datatype D1HashMap where
+    datatypeName _ = "HashMap"
+    moduleName   _ = "Data.HashMap.Base"
+
+instance Constructor C1HashMap  where
+    conName _ = "HashMap.fromList"
+
+type Rep0HashMap k v = D1 D1HashMap (C1 C1HashMap (S1 NoSelector (Rec0 [(k, v)])))
+
+instance (Eq k, Hashable k) => Generic (HashMap k v) where
+    type Rep (HashMap k v) = Rep0HashMap k v
+    from h = M1 (M1 (M1 (K1 $ toList h)))
+    to (M1 (M1 (M1 (K1 l)))) = fromList l
 #endif


### PR DESCRIPTION
we want Generics for everything (otherwise we can't derive Generics for any data types which contain these without creating orphan instances)

the end-goal is to have all of these: https://gist.github.com/kuk0/92fff1c91c526ffb0a9e
and be able to derive instances for e.g. TextShow or Text.PrettyPrint.Generic.Pretty
