### PR TITLE
Don't `inline` popcount

### DIFF
--- a/cbits/popc.c
+++ b/cbits/popc.c
@@ -261,7 +261,7 @@ static char popcount_table_8[256] = {
 };
 /* Table-driven popcount, with 8-bit tables */
 /* 6 ops plus 4 casts and 4 lookups, 0 long immediates, 4 stages */
-inline uint32_t
+uint32_t
 popcount(uint32_t x)
 {
     return popcount_table_8[(uint8_t)x] +


### PR DESCRIPTION
This makes no sense as we need `popcount()` to exist as external symbol. In fact this breaks with C99 compilers
which rightfully detect that `popcount` is not used at all, and therefore compile `popc.c` to an essentially empty  `popc.o` object... resulting in linker errors on GHC 7.0/7.2 when using such clever compilers...