### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/benchmarks/unordered-containers-benchmarks.cabal
+++ b/benchmarks/unordered-containers-benchmarks.cabal
@@ -20,6 +20,9 @@ executable unordered-containers-benchmarks
     Data.HashMap.Unsafe
     Data.HashMap.UnsafeShift
     Data.HashSet
+    Util.ByteString
+    Util.Int
+    Util.String
   build-depends:
     base,
     bytestring,

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -149,6 +149,11 @@ benchmark benchmarks
   main-is: Benchmarks.hs
   type: exitcode-stdio-1.0
 
+  other-modules:
+    Util.ByteString
+    Util.Int
+    Util.String
+
   build-depends:
     base,
     bytestring,


### PR DESCRIPTION
Currently, the benchmarks fail to compile when obtained from Hackage since `cabal sdist` doesn't distribute some `Util` files with the tarball. This PR fixes it by including these modules in the `other-modules` stanza of `unordered-containers.cabal`.

See also https://github.com/iu-parfunc/sc-haskell/issues/7