### PR TITLE
Fix benchmark compilation on stack

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -150,6 +150,14 @@ benchmark benchmarks
   type: exitcode-stdio-1.0
 
   other-modules:
+    Data.HashMap.Array
+    Data.HashMap.Base
+    Data.HashMap.Lazy
+    Data.HashMap.PopCount
+    Data.HashMap.Strict
+    Data.HashMap.Unsafe
+    Data.HashMap.UnsafeShift
+    Data.HashSet
     Util.ByteString
     Util.Int
     Util.String


### PR DESCRIPTION
Sorry to keep bombarding you with pull requests of this nature, but I didn't realize during #134 that `stack` is stricter than `cabal-install` about listing things in `other-modules`. Whereas `cabal-install` only cares if it can find the modules it needs somewhere in `hs-source-dirs` (i.e., if `cabal sdist` happens to grab them somehow), `stack` explicitly requires every dependent module to be listed in an `other-modules` stanza...

Anyway, the fix is once again simple, one just has to cram more stuff into `unordered-containers.cabal`.