### PR TITLE
Don't use -fregs-graph

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -49,8 +49,6 @@ library
   ghc-options: -Wall -O2
   if impl(ghc >= 6.8)
     ghc-options: -fwarn-tabs
-  if impl(ghc > 6.10)
-    ghc-options: -fregs-graph
   if flag(debug)
     cpp-options: -DASSERTS
 


### PR DESCRIPTION
This option has been somewhat broken and therefore 
disabled for the last several GHC releases. See GHC #7679.