### PR TITLE
HashSet: Add Semigroup instance

### DIFF
--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -77,7 +77,8 @@ import Data.Data hiding (Typeable)
 import Data.HashMap.Base (HashMap, foldrWithKey, equalKeys)
 import Data.Hashable (Hashable(hashWithSalt))
 #if __GLASGOW_HASKELL__ >= 711
-import Data.Semigroup (Semigroup(..), Monoid(..))
+import Data.Semigroup (Semigroup(..))
+import Data.Monoid (Monoid(..))
 #elif __GLASGOW_HASKELL__ < 709
 import Data.Monoid (Monoid(..))
 #endif


### PR DESCRIPTION
This will be necessary under GHC 8.4.