### PR TITLE
Add HashMap.insertWithKey.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
  * Remove support for GHC versions before 7.8. (Thanks, Dmitry Ivanov!)
  * Use `SmallArray#` instead of `Array#` for GHC versions 7.10 and above.
    (Thanks, Dmitry Ivanov!)
+ * Add `HashMap.insertWithKey`.
 
 ## 0.2.8.0
 

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -23,6 +23,7 @@ module Data.HashMap.Base
     , (!)
     , insert
     , insertWith
+    , insertWithKey
     , unsafeInsert
     , delete
     , adjust
@@ -654,6 +655,48 @@ unsafeInsertWith f k0 v0 m0 = runST (go h0 k0 v0 0 m0)
         | h == hy   = return $! Collision h (updateOrSnocWith f k x v)
         | otherwise = go h k x s $ BitmapIndexed (mask hy s) (A.singleton t)
 {-# INLINABLE unsafeInsertWith #-}
+
+-- | /O(log n)/ Associate the value with the key in this map.  If this map
+-- previously contained a mapping for the key, the old value is replaced by the
+-- result of applying the given function to the key, the new value, and the old
+-- value.
+--
+-- ==== __Examples__
+--
+-- > insertWithKey f k v map
+-- >   where f k new old = if someCondition k then new else old
+insertWithKey :: (Eq k, Hashable k) => (k -> v -> v -> v) -> k -> v -> HashMap k v
+               -> HashMap k v
+insertWithKey f k0 v0 m0 = go h0 k0 v0 0 m0
+  where
+    h0 = hash k0
+    go !h !k x !_ Empty = Leaf h (L k x)
+    go h k x s (Leaf hy l@(L ky y))
+        | hy == h = if ky == k
+                    then Leaf h (L k (f k x y))
+                    else collision h l (L k x)
+        | otherwise = runST (two s h k x hy ky y)
+    go h k x s (BitmapIndexed b ary)
+        | b .&. m == 0 =
+            let ary' = A.insert ary i $! Leaf h (L k x)
+            in bitmapIndexedOrFull (b .|. m) ary'
+        | otherwise =
+            let st   = A.index ary i
+                st'  = go h k x (s+bitsPerSubkey) st
+                ary' = A.update ary i $! st'
+            in BitmapIndexed b ary'
+      where m = mask h s
+            i = sparseIndex b m
+    go h k x s (Full ary) =
+        let st   = A.index ary i
+            st'  = go h k x (s+bitsPerSubkey) st
+            ary' = update16 ary i $! st'
+        in Full ary'
+      where i = index h s
+    go h k x s t@(Collision hy v)
+        | h == hy   = Collision h (updateOrSnocWithKey f k x v)
+        | otherwise = go h k x s $ BitmapIndexed (mask hy s) (A.singleton t)
+{-# INLINABLE insertWithKey #-}
 
 -- | /O(log n)/ Remove the mapping for the specified key from this map
 -- if present.

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -590,7 +590,7 @@ two = go
 insertWith :: (Eq k, Hashable k) => (v -> v -> v) -> k -> v -> HashMap k v
             -> HashMap k v
 insertWith f k v m = insertWithKey (const f) k v m
-{-# INLINABLE insertWith #-}
+{-# INLINE insertWith #-}
 
 -- | In-place update version of insertWith
 unsafeInsertWith :: forall k v. (Eq k, Hashable k)

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -42,6 +42,7 @@ module Data.HashMap.Lazy
     , (!)
     , insert
     , insertWith
+    , insertWithKey
     , delete
     , adjust
     , update

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -42,6 +42,7 @@ module Data.HashMap.Strict
     , (!)
     , insert
     , insertWith
+    , insertWithKey
     , delete
     , adjust
     , update

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -217,6 +217,16 @@ main = do
             , bench "ByteString" $ whnf (insert elemsBS) hmbs
             , bench "Int" $ whnf (insert elemsI) hmi
             ]
+          , bgroup "insertWith"
+            [ bench "String" $ whnf (insertWith elems) HM.empty
+            , bench "ByteString" $ whnf (insertWith elemsBS) HM.empty
+            , bench "Int" $ whnf (insertWith elemsI) HM.empty
+            ]
+          , bgroup "insertWithKey"
+            [ bench "String" $ whnf (insertWithKey elems) HM.empty
+            , bench "ByteString" $ whnf (insertWithKey elemsBS) HM.empty
+            , bench "Int" $ whnf (insertWithKey elemsI) HM.empty
+            ]
           , bgroup "delete"
             [ bench "String" $ whnf (delete keys) hm
             , bench "ByteString" $ whnf (delete keysBS) hmbs
@@ -301,6 +311,27 @@ insert xs m0 = foldl' (\m (k, v) -> HM.insert k v m) m0 xs
                       -> HM.HashMap String Int #-}
 {-# SPECIALIZE insert :: [(BS.ByteString, Int)] -> HM.HashMap BS.ByteString Int
                       -> HM.HashMap BS.ByteString Int #-}
+
+insertWith :: (Eq k, Hashable k) => [(k, Int)] -> HM.HashMap k Int
+       -> HM.HashMap k Int
+insertWith xs m0 = foldl' (\m (k, v) -> HM.insertWith (+) k v m) m0 xs
+{-# SPECIALIZE insertWith :: [(Int, Int)] -> HM.HashMap Int Int
+                          -> HM.HashMap Int Int #-}
+{-# SPECIALIZE insertWith :: [(String, Int)] -> HM.HashMap String Int
+                          -> HM.HashMap String Int #-}
+{-# SPECIALIZE insertWith :: [(BS.ByteString, Int)] -> HM.HashMap BS.ByteString Int
+                          -> HM.HashMap BS.ByteString Int #-}
+
+insertWithKey :: (Eq k, Hashable k) => [(k, Int)] -> HM.HashMap k Int
+              -> HM.HashMap k Int
+insertWithKey xs m0 = foldl' (\m (k, v) -> HM.insertWithKey f k v m) m0 xs
+  where f = const (+)
+{-# SPECIALIZE insertWithKey :: [(Int, Int)] -> HM.HashMap Int Int
+                             -> HM.HashMap Int Int #-}
+{-# SPECIALIZE insertWithKey :: [(String, Int)] -> HM.HashMap String Int
+                             -> HM.HashMap String Int #-}
+{-# SPECIALIZE insertWithKey :: [(BS.ByteString, Int)] -> HM.HashMap BS.ByteString Int
+                             -> HM.HashMap BS.ByteString Int #-}
 
 delete :: (Eq k, Hashable k) => [k] -> HM.HashMap k Int -> HM.HashMap k Int
 delete xs m0 = foldl' (\m k -> HM.delete k m) m0 xs

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -18,6 +18,7 @@ import qualified Data.HashMap.Lazy as HM
 #endif
 import qualified Data.Map as M
 import Test.QuickCheck (Arbitrary, Property, (==>), (===))
+import Test.QuickCheck.Function (Fun, apply)
 import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
@@ -147,12 +148,14 @@ pDeleteCollision k1 k2 k3 idx = (k1 /= k2) && (k2 /= k3) && (k1 /= k3) ==>
         | which == 2 = k1
         | otherwise = error "Impossible"
 
-pInsertWith :: Key -> [(Key, Int)] -> Bool
-pInsertWith k = M.insertWith (+) k 1 `eq_` HM.insertWith (+) k 1
+pInsertWith :: Fun (Int, Int) Int -> Key -> [(Key, Int)] -> Bool
+pInsertWith f k =
+  M.insertWith f' k 1 `eq_` HM.insertWith f' k 1
+  where f' = curry . apply $ f
 
-pInsertWithKey :: Key -> [(Key, Int)] -> Bool
-pInsertWithKey k = M.insertWithKey f k 1 `eq_` HM.insertWithKey f k 1
-  where f (K k') a b = if k' >= 0 then a else b
+pInsertWithKey :: Fun (Int, Int, Int) Int -> Key -> [(Key, Int)] -> Bool
+pInsertWithKey f k = M.insertWithKey f' k 1 `eq_` HM.insertWithKey f' k 1
+  where f' k' v1 v2 = apply f (unK k', v1, v2)
 
 pAdjust :: Key -> [(Key, Int)] -> Bool
 pAdjust k = M.adjust succ k `eq_` HM.adjust succ k

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -18,7 +18,7 @@ import qualified Data.HashMap.Lazy as HM
 #endif
 import qualified Data.Map as M
 import Test.QuickCheck (Arbitrary, CoArbitrary, Property, (==>), (===))
-import Test.QuickCheck.Function (Fun, Function(function), apply, functionMap)
+import Test.QuickCheck.Function (Fun(Fun), Function(function), apply, functionMap)
 import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
@@ -156,9 +156,14 @@ pInsertWith f k =
   M.insertWith f' k 1 `eq_` HM.insertWith f' k 1
   where f' = curry . apply $ f
 
-pInsertWithKey :: Fun (Key, (Int, Int)) Int -> Key -> [(Key, Int)] -> Bool
+-- | Extracts the value of a ternary function.
+-- Copied from Test.QuickCheck.Function.applyFun3
+applyFun3 :: Fun (a, b, c) d -> (a -> b -> c -> d)
+applyFun3 (Fun _ f) a b c = f (a, b, c)
+
+pInsertWithKey :: Fun (Key, Int, Int) Int -> Key -> [(Key, Int)] -> Bool
 pInsertWithKey f k = M.insertWithKey f' k 1 `eq_` HM.insertWithKey f' k 1
-  where f' = curry . curry (apply f)
+  where f' = applyFun3 f
 
 pAdjust :: Key -> [(Key, Int)] -> Bool
 pAdjust k = M.adjust succ k `eq_` HM.adjust succ k

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -150,6 +150,10 @@ pDeleteCollision k1 k2 k3 idx = (k1 /= k2) && (k2 /= k3) && (k1 /= k3) ==>
 pInsertWith :: Key -> [(Key, Int)] -> Bool
 pInsertWith k = M.insertWith (+) k 1 `eq_` HM.insertWith (+) k 1
 
+pInsertWithKey :: Key -> [(Key, Int)] -> Bool
+pInsertWithKey k = M.insertWithKey f k 1 `eq_` HM.insertWithKey f k 1
+  where f (K k') a b = if k' >= 0 then a else b
+
 pAdjust :: Key -> [(Key, Int)] -> Bool
 pAdjust k = M.adjust succ k `eq_` HM.adjust succ k
 
@@ -311,6 +315,7 @@ tests =
       , testProperty "delete" pDelete
       , testProperty "deleteCollision" pDeleteCollision
       , testProperty "insertWith" pInsertWith
+      , testProperty "insertWithKey" pInsertWithKey
       , testProperty "adjust" pAdjust
       , testProperty "updateAdjust" pUpdateAdjust
       , testProperty "updateDelete" pUpdateDelete

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -80,6 +80,15 @@ pInsertWithValueStrict f k v m
     | HM.member k m = isBottom $ HM.insertWith (const2 bottom) k v m
     | otherwise     = isBottom $ HM.insertWith f k bottom m
 
+pInsertWithKeyKeyStrict :: (Key -> Int -> Int -> Int) -> Int -> HashMap Key Int -> Bool
+pInsertWithKeyKeyStrict f v m = isBottom $ HM.insertWithKey f bottom v m
+
+pInsertWithKeyValueStrict :: (Key -> Int -> Int -> Int) -> Key -> Int -> HashMap Key Int
+                          -> Bool
+pInsertWithKeyValueStrict f k v m
+    | HM.member k m = isBottom $ HM.insertWithKey (const2 bottom) k v m
+    | otherwise     = isBottom $ HM.insertWithKey f k bottom m
+
 pFromListKeyStrict :: Bool
 pFromListKeyStrict = isBottom $ HM.fromList [(undefined :: Key, 1 :: Int)]
 
@@ -169,6 +178,8 @@ tests =
       , testProperty "insert is value-strict" pInsertValueStrict
       , testProperty "insertWith is key-strict" pInsertWithKeyStrict
       , testProperty "insertWith is value-strict" pInsertWithValueStrict
+      , testProperty "insertWithKey is key-strict" pInsertWithKeyKeyStrict
+      , testProperty "insertWithKey is value-strict" pInsertWithKeyValueStrict
       , testProperty "fromList is key-strict" pFromListKeyStrict
       , testProperty "fromList is value-strict" pFromListValueStrict
       , testProperty "fromListWith is key-strict" pFromListWithKeyStrict

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -84,15 +84,20 @@ pInsertWithValueStrict f k v m
     | HM.member k m = isBottom $ HM.insertWith (const2 bottom) k v m
     | otherwise     = isBottom $ HM.insertWith (curry . apply $ f) k bottom m
 
-pInsertWithKeyKeyStrict :: Fun (Key, (Int, Int)) Int -> Int -> HashMap Key Int -> Bool
-pInsertWithKeyKeyStrict f v m =
-  isBottom $ HM.insertWithKey (curry . curry (apply f)) bottom v m
+-- | Extracts the value of a ternary function.
+-- Copied from Test.QuickCheck.Function.applyFun3
+applyFun3 :: Fun (a, b, c) d -> (a -> b -> c -> d)
+applyFun3 (Fun _ f) a b c = f (a, b, c)
 
-pInsertWithKeyValueStrict :: Fun (Key, (Int, Int)) Int -> Key -> Int -> HashMap Key Int
+pInsertWithKeyKeyStrict :: Fun (Key, Int, Int) Int -> Int -> HashMap Key Int -> Bool
+pInsertWithKeyKeyStrict f v m =
+  isBottom $ HM.insertWithKey (applyFun3 f) bottom v m
+
+pInsertWithKeyValueStrict :: Fun (Key, Int, Int) Int -> Key -> Int -> HashMap Key Int
                           -> Bool
 pInsertWithKeyValueStrict f k v m
-    | HM.member k m = isBottom $ HM.insertWithKey (const2 bottom) k v m
-    | otherwise     = isBottom $ HM.insertWithKey (curry . curry (apply f)) k bottom m
+    | HM.member k m = isBottom $ HM.insertWithKey (const3 bottom) k v m
+    | otherwise     = isBottom $ HM.insertWithKey (applyFun3 f) k bottom m
 
 pFromListKeyStrict :: Bool
 pFromListKeyStrict = isBottom $ HM.fromList [(undefined :: Key, 1 :: Int)]
@@ -206,3 +211,6 @@ keyStrict f m = isBottom $ f bottom m
 
 const2 :: a -> b -> c -> a
 const2 x _ _ = x
+
+const3 :: a -> b -> c -> d -> a
+const3 x _ _ _ = x


### PR DESCRIPTION
This function is present in the container's Map interface, [Map.insertWithKey](https://hackage.haskell.org/package/containers-0.5.10.2/docs/Data-Map-Strict.html#v:insertWithKey), this brings more consistency to the `HashMap` interface so that it can more easily be used as a drop in replacement for `Data.Map` if desired.

This partially addresses https://github.com/tibbe/unordered-containers/issues/172.