### PR TITLE
Add HashMap.alterF.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
  * Remove support for GHC versions before 7.8. (Thanks, Dmitry Ivanov!)
  * Use `SmallArray#` instead of `Array#` for GHC versions 7.10 and above.
    (Thanks, Dmitry Ivanov!)
+ * Add `HashMap.alterF`.
 
 ## 0.2.8.0
 

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -468,9 +468,7 @@ lookup k0 m0 = go h0 k0 0 m0
 --   Key not in map           => Absent
 --   Key in map, no collision => Alone v
 --   Key in map, collision    => Collide v position
-lookupRecordCollision
-  :: (Eq k, Hashable k)
-  => Hash -> k -> Int -> HashMap k v -> LookupRes v
+lookupRecordCollision :: Eq k => Hash -> k -> Int -> HashMap k v -> LookupRes v
 lookupRecordCollision !_ !_ !_ Empty = Absent
 lookupRecordCollision h k _ (Leaf hx (L kx x))
     | h == hx && k == kx = Present x (-1)
@@ -501,7 +499,6 @@ lookupDefault def k t = case lookup k t of
     Just v -> v
     _      -> def
 {-# INLINABLE lookupDefault #-}
-
 
 -- | /O(log n)/ Return the value to which the specified key is mapped.
 -- Calls 'error' if this map contains no mapping for the key.
@@ -832,9 +829,9 @@ delete k0 m0 = go h0 k0 0 m0
     go h k s t@(Full ary) =
         let !st   = A.index ary i
             !st' = go h k (s+bitsPerSubkey) st
-         in if st' `ptrEq` st
-             then t
-             else case st' of
+        in if st' `ptrEq` st
+           then t
+           else case st' of
             Empty ->
                 let ary' = A.delete ary i
                     bm   = fullNodeMask .&. complement (1 `unsafeShiftL` i)

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -574,8 +574,7 @@ insert k0 v0 m0 = go h0 k0 v0 0 m0
 -- We can skip:
 --  - the key equality check on a Leaf
 --  - check for its existence in the array for a hash collision
-insertNewKey :: Hashable k
-             => Hash -> k -> v -> Int -> HashMap k v -> HashMap k v
+insertNewKey :: Hash -> k -> v -> Int -> HashMap k v -> HashMap k v
 insertNewKey !h !k x !_ Empty = Leaf h (L k x)
 insertNewKey h k x s (Leaf hy l@(L ky y))
     | hy == h = collision h l (L k x)
@@ -624,9 +623,7 @@ insertNewKey h k x s t@(Collision hy v)
 --
 -- We can skip:
 --  - the key equality check on a Leaf, we know the leaf must be for this key
-insertKeyExists
-  :: Hashable k
-  => Int -> Hash -> k -> v -> Int -> HashMap k v -> HashMap k v
+insertKeyExists :: Int -> Hash -> k -> v -> Int -> HashMap k v -> HashMap k v
 insertKeyExists _collPos h k x s t@(Leaf hy (L ky y))
     | hy == h = if x `ptrEq` y
                 then t
@@ -864,7 +861,7 @@ delete k0 m0 = go h0 k0 0 m0
 --
 -- We can skip:
 --  - the key equality check on the leaf, if we reach a leaf it must be the key
-deleteKeyExists :: Hashable k => Int -> Hash -> k -> Int -> HashMap k v -> HashMap k v
+deleteKeyExists :: Int -> Hash -> k -> Int -> HashMap k v -> HashMap k v
 deleteKeyExists _collPos h _ _ t@(Leaf hy (L _ _))
   -- TODO(mrenaud): Can this comparison be removed?
     | hy == h = Empty

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -830,8 +830,8 @@ delete k0 m0 = go h0 k0 0 m0
         let !st   = A.index ary i
             !st' = go h k (s+bitsPerSubkey) st
         in if st' `ptrEq` st
-           then t
-           else case st' of
+            then t
+            else case st' of
             Empty ->
                 let ary' = A.delete ary i
                     bm   = fullNodeMask .&. complement (1 `unsafeShiftL` i)

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -611,16 +611,15 @@ insertNewKey h k x s t@(Collision hy v)
 {-# INLINABLE insertNewKey #-}
 
 
--- Insert optimized for the case when we know the key is in the map and does not
--- have a hash collision.
+-- Insert optimized for the case when we know the key is in the map.
 --
 -- It is only valid to call this when the key exists in the map and you know the
 -- hash collision position if there was one. This information can be obtained
 -- from 'lookupRecordCollision'. If there is no collision pass (-1) as collPos
 -- (first argument).
 --
--- We can skip:
---  - the key equality check on a Leaf, we know the leaf must be for this key
+-- We can skip the key equality check on a Leaf because we know the leaf must be
+-- for this key.
 insertKeyExists :: Int -> Hash -> k -> v -> Int -> HashMap k v -> HashMap k v
 insertKeyExists _collPos h k x s t@(Leaf hy (L ky y))
     | hy == h = if x `ptrEq` y
@@ -960,6 +959,9 @@ alter f k m =
 -- | /O(log n)/  The expression (@'alterF' f k map@) alters the value @x@ at
 -- @k@, or absence thereof. @alterF@ can be used to insert, delete, or update
 -- a value in a map.
+--
+-- Note: 'alterF' is a flipped version of the 'at' combinator from
+-- 'Control.Lens.At'.
 --
 -- @since 0.2.9
 alterF :: (Functor f, Eq k, Hashable k)

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -961,7 +961,7 @@ alter f k m =
 -- a value in a map.
 --
 -- Note: 'alterF' is a flipped version of the 'at' combinator from
--- 'Control.Lens.At'.
+-- <https://hackage.haskell.org/package/lens-4.15.4/docs/Control-Lens-At.html#v:at Control.Lens.At>.
 --
 -- @since 0.2.9
 alterF :: (Functor f, Eq k, Hashable k)
@@ -990,7 +990,6 @@ alterF f k m = (<$> f mv) $ \fres ->
 
       -- Key existed before, no hash collision
       Present v collPos ->
-        -- TODO(m-renaud): Verify ptrEq is valid here.
         if v `ptrEq` v'
         -- If the value is identical, no-op
         then m

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -46,6 +46,7 @@ module Data.HashMap.Lazy
     , adjust
     , update
     , alter
+    , alterF
 
       -- * Combine
       -- ** Union

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -259,7 +259,7 @@ alter f k m =
 -- a value in a map.
 --
 -- Note: 'alterF' is a flipped version of the 'at' combinator from
--- 'Control.Lens.At'.
+-- <https://hackage.haskell.org/package/lens-4.15.4/docs/Control-Lens-At.html#v:at Control.Lens.At>.
 --
 -- @since 0.2.9
 alterF :: (Functor f, Eq k, Hashable k)
@@ -288,7 +288,6 @@ alterF f k m = (<$> f mv) $ \fres ->
 
       -- Key existed before, no hash collision
       Present v collPos ->
-        -- TODO(m-renaud): Verify ptrEq is valid here.
         if v `ptrEq` v'
         -- If the value is identical, no-op
         then m

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -277,7 +277,7 @@ alterF f k m = (<$> f mv) $ \fres ->
       Absent -> m
 
       -- Key did exist, no collision
-      Present _ collPos -> deleteKeyExists collPos h k m
+      Present collPos _ -> deleteKeyExists collPos h k m
 
     ------------------------------
     -- Update value
@@ -287,7 +287,7 @@ alterF f k m = (<$> f mv) $ \fres ->
       Absent -> insertNewKey h k v' m
 
       -- Key existed before, no hash collision
-      Present v collPos ->
+      Present collPos v ->
         if v `ptrEq` v'
         -- If the value is identical, no-op
         then m
@@ -298,7 +298,7 @@ alterF f k m = (<$> f mv) $ \fres ->
         lookupRes = lookupRecordCollision h k m
         mv = case lookupRes of
           Absent -> Nothing
-          Present v _ -> Just v
+          Present _ v -> Just v
 {-# INLINABLE alterF #-}
 
 ------------------------------------------------------------------------

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -258,6 +258,9 @@ alter f k m =
 -- @k@, or absence thereof. @alterF@ can be used to insert, delete, or update
 -- a value in a map.
 --
+-- Note: 'alterF' is a flipped version of the 'at' combinator from
+-- 'Control.Lens.At'.
+--
 -- @since 0.2.9
 alterF :: (Functor f, Eq k, Hashable k)
        => (Maybe v -> f (Maybe v)) -> k -> HashMap k v -> f (HashMap k v)

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -90,6 +90,10 @@ module Data.HashMap.Strict
     ) where
 
 import Data.Bits ((.&.), (.|.))
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Functor((<$>))
+#endif
 import qualified Data.List as L
 import Data.Hashable (Hashable)
 import Prelude hiding (map)

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE BangPatterns, CPP, PatternGuards #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UnboxedSums #-}
 
 ------------------------------------------------------------------------
 -- |
@@ -274,20 +276,20 @@ alterF f k m = (<$> f mv) $ \fres ->
     Nothing -> case lookupRes of
 
       -- Key did not exist in the map to begin with, no-op
-      Absent -> m
+      (# (# #) | #) -> m
 
       -- Key did exist, no collision
-      Present collPos _ -> deleteKeyExists collPos h k m
+      (# | (# collPos, _ #) #) -> deleteKeyExists collPos h k m
 
     ------------------------------
     -- Update value
     Just v' -> case lookupRes of
 
       -- Key did not exist before, insert v' under a new key
-      Absent -> insertNewKey h k v' m
+      (# (# #) | #) -> insertNewKey h k v' m
 
       -- Key existed before, no hash collision
-      Present collPos v ->
+      (# | (# collPos, v #) #) ->
         if v `ptrEq` v'
         -- If the value is identical, no-op
         then m
@@ -297,8 +299,8 @@ alterF f k m = (<$> f mv) $ \fres ->
   where !h = hash k
         lookupRes = lookupRecordCollision h k m
         mv = case lookupRes of
-          Absent -> Nothing
-          Present _ v -> Just v
+          (# (# #) | #) -> Nothing
+          (# | (# _, v #) #) -> Just v
 {-# INLINABLE alterF #-}
 
 ------------------------------------------------------------------------

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -277,14 +277,14 @@ alterF f k m = (<$> f mv) $ \fres ->
       Absent -> m
 
       -- Key did exist, no collision
-      Present _ collPos -> deleteKeyExists collPos h k 0 m
+      Present _ collPos -> deleteKeyExists collPos h k m
 
     ------------------------------
     -- Update value
     Just v' -> case lookupRes of
 
       -- Key did not exist before, insert v' under a new key
-      Absent -> insertNewKey h k v' 0 m
+      Absent -> insertNewKey h k v' m
 
       -- Key existed before, no hash collision
       Present v collPos ->
@@ -292,10 +292,10 @@ alterF f k m = (<$> f mv) $ \fres ->
         -- If the value is identical, no-op
         then m
         -- If the value changed, update the value.
-        else v' `seq` insertKeyExists collPos h k v' 0 m
+        else v' `seq` insertKeyExists collPos h k v' m
 
   where !h = hash k
-        lookupRes = lookupRecordCollision h k 0 m
+        lookupRes = lookupRecordCollision h k m
         mv = case lookupRes of
           Absent -> Nothing
           Present v _ -> Just v

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -372,10 +372,15 @@ alterDelete xs m0 =
 {-# SPECIALIZE alterDelete :: [BS.ByteString] -> HM.HashMap BS.ByteString Int
                            -> HM.HashMap BS.ByteString Int #-}
 
+newtype I a = I { unI :: a }
+
+instance Functor I where
+  fmap f (I a) = I (f a)
+
 alterFInsert :: (Eq k, Hashable k) => [(k, Int)] -> HM.HashMap k Int
              -> HM.HashMap k Int
 alterFInsert xs m0 =
-  foldl' (\m (k, v) -> fromJust $ HM.alterF (const . Just . Just $ v) k m) m0 xs
+  foldl' (\m (k, v) -> unI $ HM.alterF (const . I . Just $ v) k m) m0 xs
 {-# SPECIALIZE alterFInsert :: [(Int, Int)] -> HM.HashMap Int Int
                             -> HM.HashMap Int Int #-}
 {-# SPECIALIZE alterFInsert :: [(String, Int)] -> HM.HashMap String Int
@@ -386,7 +391,7 @@ alterFInsert xs m0 =
 alterFDelete :: (Eq k, Hashable k) => [k] -> HM.HashMap k Int
              -> HM.HashMap k Int
 alterFDelete xs m0 =
-  foldl' (\m k -> fromJust $ HM.alterF (const . Just $ Nothing) k m) m0 xs
+  foldl' (\m k -> unI $ HM.alterF (const . I $ Nothing) k m) m0 xs
 {-# SPECIALIZE alterFDelete :: [Int] -> HM.HashMap Int Int
                             -> HM.HashMap Int Int #-}
 {-# SPECIALIZE alterFDelete :: [String] -> HM.HashMap String Int

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -13,7 +13,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.IntMap as IM
 import qualified Data.Map as M
 import Data.List (foldl')
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromJust, fromMaybe)
 import GHC.Generics (Generic)
 import Prelude hiding (lookup)
 
@@ -227,6 +227,46 @@ main = do
             , bench "ByteString" $ whnf (delete keysBS') hmbs
             , bench "Int" $ whnf (delete keysI') hmi
             ]
+          , bgroup "alterInsert"
+            [ bench "String" $ whnf (alterInsert elems) HM.empty
+            , bench "ByteString" $ whnf (alterInsert elemsBS) HM.empty
+            , bench "Int" $ whnf (alterInsert elemsI) HM.empty
+            ]
+          , bgroup "alterInsert-dup"
+            [ bench "String" $ whnf (alterInsert elems) hm
+            , bench "ByteString" $ whnf (alterInsert elemsBS) hmbs
+            , bench "Int" $ whnf (alterInsert elemsI) hmi
+            ]
+          , bgroup "alterDelete"
+            [ bench "String" $ whnf (alterDelete keys) hm
+            , bench "ByteString" $ whnf (alterDelete keysBS) hmbs
+            , bench "Int" $ whnf (alterDelete keysI) hmi
+            ]
+          , bgroup "alterDelete-miss"
+            [ bench "String" $ whnf (alterDelete keys') hm
+            , bench "ByteString" $ whnf (alterDelete keysBS') hmbs
+            , bench "Int" $ whnf (alterDelete keysI') hmi
+            ]
+          , bgroup "alterFInsert"
+            [ bench "String" $ whnf (alterFInsert elems) HM.empty
+            , bench "ByteString" $ whnf (alterFInsert elemsBS) HM.empty
+            , bench "Int" $ whnf (alterFInsert elemsI) HM.empty
+            ]
+          , bgroup "alterFInsert-dup"
+            [ bench "String" $ whnf (alterFInsert elems) hm
+            , bench "ByteString" $ whnf (alterFInsert elemsBS) hmbs
+            , bench "Int" $ whnf (alterFInsert elemsI) hmi
+            ]
+          , bgroup "alterFDelete"
+            [ bench "String" $ whnf (alterFDelete keys) hm
+            , bench "ByteString" $ whnf (alterFDelete keysBS) hmbs
+            , bench "Int" $ whnf (alterFDelete keysI) hmi
+            ]
+          , bgroup "alterFDelete-miss"
+            [ bench "String" $ whnf (alterFDelete keys') hm
+            , bench "ByteString" $ whnf (alterFDelete keysBS') hmbs
+            , bench "Int" $ whnf (alterFDelete keysI') hmi
+            ]
 
             -- Combine
           , bench "union" $ whnf (HM.union hmi) hmi2
@@ -309,6 +349,50 @@ delete xs m0 = foldl' (\m k -> HM.delete k m) m0 xs
                       -> HM.HashMap String Int #-}
 {-# SPECIALIZE delete :: [BS.ByteString] -> HM.HashMap BS.ByteString Int
                       -> HM.HashMap BS.ByteString Int #-}
+
+alterInsert :: (Eq k, Hashable k) => [(k, Int)] -> HM.HashMap k Int
+             -> HM.HashMap k Int
+alterInsert xs m0 =
+  foldl' (\m (k, v) -> HM.alter (const . Just $ v) k m) m0 xs
+{-# SPECIALIZE alterInsert :: [(Int, Int)] -> HM.HashMap Int Int
+                           -> HM.HashMap Int Int #-}
+{-# SPECIALIZE alterInsert :: [(String, Int)] -> HM.HashMap String Int
+                           -> HM.HashMap String Int #-}
+{-# SPECIALIZE alterInsert :: [(BS.ByteString, Int)] -> HM.HashMap BS.ByteString Int
+                           -> HM.HashMap BS.ByteString Int #-}
+
+alterDelete :: (Eq k, Hashable k) => [k] -> HM.HashMap k Int
+             -> HM.HashMap k Int
+alterDelete xs m0 =
+  foldl' (\m k -> HM.alter (const Nothing) k m) m0 xs
+{-# SPECIALIZE alterDelete :: [Int] -> HM.HashMap Int Int
+                           -> HM.HashMap Int Int #-}
+{-# SPECIALIZE alterDelete :: [String] -> HM.HashMap String Int
+                           -> HM.HashMap String Int #-}
+{-# SPECIALIZE alterDelete :: [BS.ByteString] -> HM.HashMap BS.ByteString Int
+                           -> HM.HashMap BS.ByteString Int #-}
+
+alterFInsert :: (Eq k, Hashable k) => [(k, Int)] -> HM.HashMap k Int
+             -> HM.HashMap k Int
+alterFInsert xs m0 =
+  foldl' (\m (k, v) -> fromJust $ HM.alterF (const . Just . Just $ v) k m) m0 xs
+{-# SPECIALIZE alterFInsert :: [(Int, Int)] -> HM.HashMap Int Int
+                            -> HM.HashMap Int Int #-}
+{-# SPECIALIZE alterFInsert :: [(String, Int)] -> HM.HashMap String Int
+                            -> HM.HashMap String Int #-}
+{-# SPECIALIZE alterFInsert :: [(BS.ByteString, Int)] -> HM.HashMap BS.ByteString Int
+                            -> HM.HashMap BS.ByteString Int #-}
+
+alterFDelete :: (Eq k, Hashable k) => [k] -> HM.HashMap k Int
+             -> HM.HashMap k Int
+alterFDelete xs m0 =
+  foldl' (\m k -> fromJust $ HM.alterF (const . Just $ Nothing) k m) m0 xs
+{-# SPECIALIZE alterFDelete :: [Int] -> HM.HashMap Int Int
+                            -> HM.HashMap Int Int #-}
+{-# SPECIALIZE alterFDelete :: [String] -> HM.HashMap String Int
+                            -> HM.HashMap String Int #-}
+{-# SPECIALIZE alterFDelete :: [BS.ByteString] -> HM.HashMap BS.ByteString Int
+                            -> HM.HashMap BS.ByteString Int #-}
 
 ------------------------------------------------------------------------
 -- * Map


### PR DESCRIPTION
The implementation utilizes specialized versions of lookup, insert, and delete
to guarantee that the hash is only computed once and key comparisons are done at
most once.

**Testing:**

- Property tests are added to verify that the behaviour is equivalent to that of
  `Data.Map.alterF`.
- Property tests for `alter` as well since they weren't present.

**Benchmarking**

Benchmarks added for `alter` and `alterF`. Performance is comparable to `insert` and `delete` operatiors. See https://github.com/tibbe/unordered-containers/pull/180/commits/b143063c45868fce5eb1d4275119bcf37e8b0cf3 for details.

**Open questions/follow-ups:**

- Verify that strictness is enforced properly in Data.HashMap.Strict.alterF.
- Make another pass to determine if more checks can be removed from optimized
  insert and delete operations.

This partially addresses #172. 