### PR TITLE
Fix typo in HashSet's Data instance

### DIFF
--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -196,7 +196,7 @@ fromListConstr :: Constr
 fromListConstr = mkConstr hashSetDataType "fromList" [] Prefix
 
 hashSetDataType :: DataType
-hashSetDataType = mkDataType "Data.HashSet" [fromListConstr]
+hashSetDataType = mkDataType "Data.HashSet.Base.HashSet" [fromListConstr]
 
 -- | /O(1)/ Construct an empty set.
 empty :: HashSet a


### PR DESCRIPTION
The `dataTypeOf` function in the Data instance for HashSet currently names the module ("Data.HashSet"), rather than the type itself.