### PR TITLE
Make lazy map lazy in the structure

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -1418,8 +1418,10 @@ mapWithKey f = go
   where
     go Empty = Empty
     go (Leaf h (L k v)) = Leaf h $ L k (f k v)
-    go (BitmapIndexed b ary) = BitmapIndexed b $ A.map' go ary
-    go (Full ary) = Full $ A.map' go ary
+    go (BitmapIndexed b ary) = BitmapIndexed b $ A.map go ary
+    go (Full ary) = Full $ A.map go ary
+    -- Why map strictly over collision arrays? Because there's no
+    -- point suspending the O(1) work this does for each leaf.
     go (Collision h ary) = Collision h $
                            A.map' (\ (L k v) -> L k (f k v)) ary
 {-# INLINE mapWithKey #-}


### PR DESCRIPTION
Previously, the lazy version of `mapWithKey` forced the whole structure
(except the leaves). For a large `HashMap`, it's usually much
better to be incremental. This also makes `mapWithKey` consistent
with `traverseWithKey`.

Fixes #195