### PR TITLE
Extend Foldable (foldl', null, length)

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -201,11 +201,12 @@ instance Foldable.Foldable (HashMap k) where
     {-# INLINE foldr #-}
     foldl' = Data.HashMap.Base.foldl'
     {-# INLINE foldl' #-}
+#if MIN_VERSION_base(4,8,0)
     null = Data.HashMap.Base.null
     {-# INLINE null #-}
     length = Data.HashMap.Base.size
     {-# INLINE length #-}
-
+#endif
 
 #if __GLASGOW_HASKELL__ >= 711
 instance (Eq k, Hashable k) => Semigroup (HashMap k v) where

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -197,7 +197,15 @@ instance Functor (HashMap k) where
     fmap = map
 
 instance Foldable.Foldable (HashMap k) where
-    foldr f = foldrWithKey (const f)
+    foldr = Data.HashMap.Base.foldr
+    {-# INLINE foldr #-}
+    foldl' = Data.HashMap.Base.foldl'
+    {-# INLINE foldl' #-}
+    null = Data.HashMap.Base.null
+    {-# INLINE null #-}
+    length = Data.HashMap.Base.size
+    {-# INLINE length #-}
+
 
 #if __GLASGOW_HASKELL__ >= 711
 instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
@@ -1530,7 +1538,7 @@ intersectionWithKey f a b = foldlWithKey' go empty a
 -- | /O(n)/ Reduce this map by applying a binary operator to all
 -- elements, using the given starting value (typically the
 -- left-identity of the operator).  Each application of the operator
--- is evaluated before using the result in the next application. 
+-- is evaluated before using the result in the next application.
 -- This function is strict in the starting value.
 foldl' :: (a -> v -> a) -> a -> HashMap k v -> a
 foldl' f = foldlWithKey' (\ z _ v -> f z v)
@@ -1539,7 +1547,7 @@ foldl' f = foldlWithKey' (\ z _ v -> f z v)
 -- | /O(n)/ Reduce this map by applying a binary operator to all
 -- elements, using the given starting value (typically the
 -- left-identity of the operator).  Each application of the operator
--- is evaluated before using the result in the next application.  
+-- is evaluated before using the result in the next application.
 -- This function is strict in the starting value.
 foldlWithKey' :: (a -> k -> v -> a) -> a -> HashMap k v -> a
 foldlWithKey' f = go

--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -142,12 +142,14 @@ instance Foldable.Foldable HashSet where
     {-# INLINE foldr #-}
     foldl' = Data.HashSet.Base.foldl'
     {-# INLINE foldl' #-}
+#if MIN_VERSION_base(4,8,0)
     toList = Data.HashSet.Base.toList
     {-# INLINE toList #-}
     null = Data.HashSet.Base.null
     {-# INLINE null #-}
     length = Data.HashSet.Base.size
     {-# INLINE length #-}
+#endif
 
 #if __GLASGOW_HASKELL__ >= 711
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where

--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -140,6 +140,14 @@ instance Ord1 HashSet where
 instance Foldable.Foldable HashSet where
     foldr = Data.HashSet.Base.foldr
     {-# INLINE foldr #-}
+    foldl' = Data.HashSet.Base.foldl'
+    {-# INLINE foldl' #-}
+    toList = Data.HashSet.Base.toList
+    {-# INLINE toList #-}
+    null = Data.HashSet.Base.null
+    {-# INLINE null #-}
+    length = Data.HashSet.Base.size
+    {-# INLINE length #-}
 
 #if __GLASGOW_HASKELL__ >= 711
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where


### PR DESCRIPTION
The Foldable instance was slightly extended for issue for Issue #222 out of boredom. Namely adding foldl', null, length, on both HashMap and HashSet. Due to its usage in HashSet, I assumed the `INLINE` pragma was appropriate.