### PR TITLE
Allow hashable-1.3

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -43,7 +43,7 @@ library
   build-depends:
     base >= 4.7 && < 5,
     deepseq >= 1.1,
-    hashable >= 1.0.1.1 && < 1.3
+    hashable >= 1.0.1.1 && < 1.4
 
   default-language: Haskell2010
 


### PR DESCRIPTION
New major hashable-1.3 have been released:

There are changes which don't manifest in types https://hackage.haskell.org/package/hashable-1.3.0.0/changelog

- Semantic change of Hashable Arg instance to not hash the second argument of Arg in order to be consistent with Eq Arg (#171)
- Semantic change of Hashable Float and Hashable Double instances to hash -0.0 and 0.0 to the same value (#173)
- Add Hashable instance for Fingerprint (#156)
- Add new Data.Hashable.Generic module providing the default implementations genericHashWithSalt and genericLiftHashWithSalt together with other Generics support helpers (#148, #178)
- Bump minimum version requirement of base to base-4.5 (i.e. GHC >= 7.4)

Yet, I don't think they affect `unordered-containers` directly.

(Some *might* depend on `Hashable Float` behavior using e.g. `HashSet`, while not depending on `hashable` directly; but that's nothing `unordered-containers` can do about)