### PR TITLE
Fix export list in Hash.HashMap.Strict.Base.hs.

### DIFF
--- a/Data/HashMap/Strict/Base.hs
+++ b/Data/HashMap/Strict/Base.hs
@@ -39,6 +39,7 @@ module Data.HashMap.Strict.Base
     , size
     , HM.member
     , HM.lookup
+    , HM.findWithDefault
     , lookupDefault
     , (!)
     , insert


### PR DESCRIPTION
This was causing CI failures, see:

https://travis-ci.org/github/tibbe/unordered-containers/jobs/666393736?utm_medium=notification&utm_source=github_status

There must have been an incorrect merge somewhere along the line in #176 

@treeowl FYI for CI breakage at HEAD.
